### PR TITLE
Prefer using blkid instead of ls + grep + cut to get the partition's UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ The `options` line depends on the disk method you used.
 To get the [partition UUID](https://wiki.archlinux.org/index.php/Persistent_block_device_naming#by-uuid) easily (since we can't copy/paste anything at this point):
 
 ```sh
-ls -l /dev/disk/by-uuid/ | grep <partition name> | cut -f 9 -d " " >> /boot/loader/entries/arch.conf
+blkid -s PARTUUID -o value /dev/<partition name>
 ```
 
 ## Intel Microcode

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ The `options` line depends on the disk method you used.
 To get the [partition UUID](https://wiki.archlinux.org/index.php/Persistent_block_device_naming#by-uuid) easily (since we can't copy/paste anything at this point):
 
 ```sh
-blkid -s PARTUUID -o value /dev/<partition name> >> /boot/loader/entries/arch.conf
+blkid -s UUID -o value /dev/<sda2 name> >> /boot/loader/entries/arch.conf
 ```
 
 ## Intel Microcode

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ The `options` line depends on the disk method you used.
 To get the [partition UUID](https://wiki.archlinux.org/index.php/Persistent_block_device_naming#by-uuid) easily (since we can't copy/paste anything at this point):
 
 ```sh
-blkid -s PARTUUID -o value /dev/<partition name>
+blkid -s PARTUUID -o value /dev/<partition name> >> /boot/loader/entries/arch.conf
 ```
 
 ## Intel Microcode


### PR DESCRIPTION
The [Arch's official documentation](https://wiki.archlinux.org/index.php/Systemd-boot#Installing_the_EFI_boot_manager) uses blkid to get the UUID, which is shorter than the current command.